### PR TITLE
Fix rewriteRefs and no-S3 mode

### DIFF
--- a/processImages.js
+++ b/processImages.js
@@ -1,7 +1,6 @@
 const request = require('request-promise')
 
 const config = require('./config')
-const { uploadImage } = require('./s3')
 
 const replaceAll = (str, obj) => {
   let newStr = str
@@ -20,6 +19,8 @@ const processImages = async (content) => {
   const imgMatchAll = new RegExp(imgRegExp, 'g')
 
   if (config.s3Bucket) {
+    const { uploadImage } = require('./s3')
+
     return Promise.all(
       (content.match(imgMatchAll) || [])
         .map(img => {

--- a/rewriteRefs.js
+++ b/rewriteRefs.js
@@ -8,7 +8,7 @@ const main = async () => {
   const refsPath = `${config.source.repo}.git/packed-refs`
   const refs = (await fs.readFile(refsPath, { encoding: 'utf-8' }))
     .split(os.EOL)
-    .map(ref => ref.replace(/refs\/pull\/([0-9]+)\/head/, 'refs/heads/pr$1head'))
+    .map(ref => ref.replace(/refs\/pull\/([0-9]+)\/(\w+)/g, 'refs/heads/pr$1$2'))
     .join(os.EOL)
   
   await fs.move(refsPath, `${refsPath}.back`)


### PR DESCRIPTION
Thanks for this project — it was just what I was looking for to move from GitHub Enterprise to GitHub.com. And it seems to work well, but I had to make a couple tweaks for it to work for me:

* `rewriteRefs.js` only mapped the first PR head, so it didn't work with multiple PRs. Missing `g` flag on the RegExp.
* `rewriteRefs.js` handled refs of the form `refs/pull/134/head` but didn't handle refs of the form `refs/pull/134/merge`. (I don't know what they mean, to be honest...) I modified the RegExp to change these too, but I'm not sure whether there need to be corresponding changes elsewhere...?
* `processImages.js` crashed for me with message `EC2 Metadata roleName request returned error` and `connect ENETUNREACH 169.254.169.254:80`, possibly because I don't have EC2 configured? So I moved the `require` of EC2 inside the `if` so that it doesn't apply to me.